### PR TITLE
timeout when connecting, workaorund for hangs on windows

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -18,4 +18,4 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - run: bundle exec rspec
+    - run: bundle exec rspec -f d

--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -4,6 +4,7 @@ name: RSpec
 on: [push, pull_request]
 jobs:
   test:
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -1,7 +1,7 @@
 # This workflow runs RSpec tests
 
 name: RSpec
-on: [push, pull_request]
+on: [push]
 jobs:
   test:
     timeout-minutes: 10

--- a/spec/connect_spec.rb
+++ b/spec/connect_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Connecting' do
 	}
 
 	it 'works when the supervisor is started first' do
-		Async do |task|
+		async_context do
 			expect(supervisor.proxies.size).to eq(0)
 			expect(site.proxies.size).to eq(1)
 			expect(site.proxies.first.state).to eq(:disconnected)
@@ -46,8 +46,6 @@ RSpec.describe 'Connecting' do
 			supervisor.start
 			site.start
 
-			raise RSMP::TimeoutError
-			
 			site_proxy = supervisor.wait_for_site site_id, timeout: timeout
 			supervisor_proxy = site.wait_for_supervisor ip, timeout: timeout
 
@@ -62,13 +60,11 @@ RSpec.describe 'Connecting' do
 
 			expect(site_proxy.state).to eq(:ready)
 			expect(supervisor_proxy.state).to eq(:ready)
-
-			task.stop
 		end
 	end
 
 	it 'works when the site is started first' do
-		Async do |task|
+		async_context do
 			expect(supervisor.proxies.size).to eq(0)
 			expect(site.proxies.size).to eq(1)
 			expect(site.proxies.first.state).to eq(:disconnected)
@@ -90,8 +86,6 @@ RSpec.describe 'Connecting' do
 
 			expect(site_proxy.state).to eq(:ready)
 			expect(supervisor_proxy.state).to eq(:ready)
-
-			task.stop
 		end
 	end
 end

--- a/spec/connect_spec.rb
+++ b/spec/connect_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe 'Connecting' do
 			supervisor.start
 			site.start
 
+			raise RSMP::TimeoutError
+			
 			site_proxy = supervisor.wait_for_site site_id, timeout: timeout
 			supervisor_proxy = site.wait_for_supervisor ip, timeout: timeout
 

--- a/spec/site_spec.rb
+++ b/spec/site_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RSMP::Site do
 				'1b206e56-31be-4739-9164-3a24d47b0aa2'
 			)
 
-			Async(transient: false) do |task|
+			async_context do
 				site = nil
 
 				# acts as a supervisior by listening for connections
@@ -68,8 +68,6 @@ RSpec.describe RSMP::Site do
 					proxy = site.proxies.first
 					expect(proxy).to be_an(RSMP::SupervisorProxy)
 					expect(proxy.state).to be(:ready)
-			  ensure
-			  	task.stop
 				end
 
 			  site = RSMP::Site.new(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'rsmp'
 require_relative 'support/connection_helper'
 require_relative 'support/site_proxy_stub'
+require_relative 'support/async_helper'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe RSMP::Supervisor do
 		end
 
 		it 'logs' do
-			Async(transient: true) do |task|
+			async_context do
 				supervisor.start
 
 				protocol.write_lines '{"mType":"rSMsg","type":"Version","RSMP":[{"vers":"3.1.5"}],"siteId":[{"sId":"RN+SI0001"}],"SXL":"1.0.15","mId":"8db00f0a-4124-406f-b3f9-ceb0dbe4aeb6"}'

--- a/spec/support/async_helper.rb
+++ b/spec/support/async_helper.rb
@@ -1,9 +1,9 @@
 require 'async'
 
 # Run block inside an Async reactor.
-# Catch errors and just return then, and use result() reo re-raise then outside the reactor,
+# Catch errors and return them, then use result() to re-raise them outside the reactor.
 # to avoid Async printing errors, which interferes with rspec output.
-# Use a transient task, to ensure that any subtask are terminated as soon as the main task completes
+# We use a transient task, to ensure that any subtask are terminated as soon as the main task completes.
 def async_context &block
 	Async transient: true do |task|
 		yield task

--- a/spec/support/async_helper.rb
+++ b/spec/support/async_helper.rb
@@ -1,11 +1,13 @@
 require 'async'
 
+# Run block inside an Async reactor.
+# Catch errors and just return then, and use result() reo re-raise then outside the reactor,
+# to avoid Async printing errors, which interferes with rspec output.
+# Use a transient task, to ensure that any subtask are terminated as soon as the main task completes
 def async_context &block
 	Async transient: true do |task|
 		yield task
 	rescue StandardError => e
 		e
-	ensure
-		task.stop later: true
 	end.result
 end

--- a/spec/support/async_helper.rb
+++ b/spec/support/async_helper.rb
@@ -1,0 +1,11 @@
+require 'async'
+
+def async_context &block
+	Async transient: true do |task|
+		yield task
+	rescue StandardError => e
+		e
+	ensure
+		task.stop later: true
+	end.result
+end


### PR DESCRIPTION
this adds a manual timeout when connecting. this is a workaround for hangs on windows.

this this change, it should be possible to start the site first, and then the supervisor.

this is not an optimal solution, since it might add delay before the connection is established. the timeout is currently set to 1.1, so it might add up to 1.1 seconds of delay when connecting.

@mikaelbroms and @otterdahl can you confirm that this works on windows? i verified this with github actions on windows-latest, which seems to be windows 2019.

