### PR TITLE
README: Remove information about submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,6 @@ $ gem install bundler
 $ bundle
 ```
 
-Install git submodules:
-The JSON Schema is is included as a git submodule. To install it:
-
-```console
-$ git submodule init     # initialize local submodule config
-$ git submodule update   # fetch submodules
-```
-
-Alternatively, you can pass --recurse-submodules to the git clone command, and it will automatically initialize and update each submodule in the repository.
-
 ## Usage
 ### Site and Supervisor
 The RSMP::Site and RSMP::Supervisor classes can be used to run a RSMP site.


### PR DESCRIPTION
Remove information about submodule
rsmp is used as a gem instead