### PR TITLE
Alarm component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rsmp (0.18.1)
+    rsmp (0.18.2)
       async (~> 1.30.3)
       async-io (~> 1.33.0)
       colorize (~> 0.8.1)

--- a/lib/rsmp/collect/alarm_collector.rb
+++ b/lib/rsmp/collect/alarm_collector.rb
@@ -14,7 +14,7 @@ module RSMP
       return false if super(message) == false
 
       # match fixed attributes
-      %w{aCId aSp ack aS sS cat pri}.each do |key|
+      %w{cId aCId aSp ack aS sS cat pri}.each do |key|
         want = @query[key]
         got = message.attribute(key)
         case want

--- a/lib/rsmp/tlc/traffic_controller.rb
+++ b/lib/rsmp/tlc/traffic_controller.rb
@@ -298,16 +298,21 @@ module RSMP
 
       def input_logic input, change
         return unless @input_programming && change != nil
-        actions = @input_programming[input]
-        return unless actions
-        if actions['raise']
-          alarm_code = actions['raise']
-          if change
-            log "Activating input #{input} is programmed to activate alarm #{alarm_code}", level: :info
-            activate_alarm alarm_code
+        action = @input_programming[input]
+        return unless action
+        if action['raise_alarm']
+          if action['component']
+            component = node.find_component action['component']
           else
-            log "Deactivating input #{input} is programmed to deactivate alarm #{alarm_code}", level: :info
-            deactivate_alarm alarm_code
+            component = node.main
+          end
+          alarm_code = action['raise_alarm']
+          if change
+            log "Activating input #{input} is programmed to raise alarm #{alarm_code} on #{component.c_id}", level: :info
+            component.activate_alarm alarm_code
+          else
+            log "Deactivating input #{input} is programmed to clear alarm #{alarm_code} on #{component.c_id}", level: :info
+            component.deactivate_alarm alarm_code
           end
         end
       end

--- a/lib/rsmp/version.rb
+++ b/lib/rsmp/version.rb
@@ -1,3 +1,3 @@
 module RSMP
-  VERSION = "0.18.1"
+  VERSION = "0.18.2"
 end


### PR DESCRIPTION
You can now set component when you configure an input to raise an alarm:


```yaml
inputs:
  total: 8
  programming:
    7:
      raise_alarm: A0301
      component: DL1
    8:
      raise_alarm: A0302
```

If not set, it will default to the main component.