### PR TITLE
add cli --core option, improve error handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rsmp (0.31.0)
+    rsmp (0.32.0)
       async (~> 2.12.0)
       async-io (~> 1.43.0)
       colorize (~> 1.1)
@@ -96,7 +96,7 @@ GEM
     simpleidn (0.2.3)
     sys-uname (1.3.0)
       ffi (~> 1.1)
-    thor (1.3.1)
+    thor (1.3.2)
     timecop (0.9.10)
 
 PLATFORMS

--- a/lib/rsmp/supervisor.rb
+++ b/lib/rsmp/supervisor.rb
@@ -94,7 +94,7 @@ module RSMP
       else
         reject_connection socket, info
       end
-    rescue ConnectionError => e
+    rescue ConnectionError, HandshakeError => e
       log "Rejected connection from #{remote_ip}:#{remote_port}, #{e.to_s}", level: :warning
       distribute_error e
     rescue StandardError => e

--- a/lib/rsmp/tlc/traffic_controller.rb
+++ b/lib/rsmp/tlc/traffic_controller.rb
@@ -15,7 +15,7 @@ module RSMP
         @signal_groups = []
         @detector_logics = []
         @plans = signal_plans
-        @cycle_time = cycle_time
+        @cycle_time = cycle_time || 10
         @num_traffic_situations = 1
 
         if inputs

--- a/lib/rsmp/tlc/traffic_controller_site.rb
+++ b/lib/rsmp/tlc/traffic_controller_site.rb
@@ -18,7 +18,10 @@ module RSMP
         unless main
           raise ConfigurationError.new "TLC must have a main component"
         end
+      end
 
+      def site_type_name
+        "TLC"
       end
 
       def start

--- a/lib/rsmp/version.rb
+++ b/lib/rsmp/version.rb
@@ -1,3 +1,3 @@
 module RSMP
-  VERSION = "0.31.0"
+  VERSION = "0.32.0"
 end


### PR DESCRIPTION
CLI option is available for both site and supervisor.
Also include some improvements to have the core version is handled, including showing it then a site starts.
Also some refactoring of exceptions are handled in the CLI code.