### PR TITLE
support changing cycle time with M0018, cycle time is now configured …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rsmp (0.32.8)
+    rsmp (0.33.0)
       async (~> 2.16)
       async-io (~> 1.43)
       colorize (~> 1.1)

--- a/config/tlc.yaml
+++ b/config/tlc.yaml
@@ -7,7 +7,6 @@ sxl_version: '1.2.1'
 components:
   main:
     TC:
-      cycle_time: 6
       ntsOId: KK+AG9998=001TC000
   signal_group:
     A1:
@@ -19,15 +18,17 @@ components:
     DL2:
 signal_plans:
   1:
-    dynamic_bands:
-      1: 0
-      2: 5
+    cycle_time: 6
     states:
       A1: '111NBB'
       A2: '11NBBB'
       B1: 'BBB11N'
       B2: 'BBB1NB'
+    dynamic_bands:
+      1: 0
+      2: 5
   2:
+    cycle_time: 6
     states:
       A1: 'NNNNBB'
       A2: 'NNNNBN'

--- a/lib/rsmp/tlc/signal_group.rb
+++ b/lib/rsmp/tlc/signal_group.rb
@@ -30,7 +30,8 @@ module RSMP
         states = plan.states[c_id]
         return default unless states
 
-        state = states[cycle_counter]
+        counter = [cycle_counter, states.length-1].min
+        state = states[counter]
         return default unless state =~ /[a-hA-G0-9N-P]/  # valid signal group states
         state
       end

--- a/lib/rsmp/tlc/signal_plan.rb
+++ b/lib/rsmp/tlc/signal_plan.rb
@@ -4,11 +4,12 @@ module RSMP
     # A signal plan is a description of how all signal groups should change
     # state over time.
     class SignalPlan
-      attr_reader :nr, :states, :dynamic_bands
-      def initialize nr:, states:, dynamic_bands:
+      attr_reader :nr, :states, :dynamic_bands, :cycle_time
+      def initialize nr:, cycle_time:, states:, dynamic_bands:
         @nr = nr
         @states = states
         @dynamic_bands = dynamic_bands || {}
+        @cycle_time = cycle_time
       end
 
       def dynamic_bands_string
@@ -23,6 +24,11 @@ module RSMP
 
       def get_band band
         @dynamic_bands[ band.to_i ]
+      end
+
+      def set_cycle_time cycle_time
+        raise ArgumentError if cycle_time < 0
+        @cycle_time = cycle_time
       end
     end
   end

--- a/lib/rsmp/tlc/traffic_controller_site.rb
+++ b/lib/rsmp/tlc/traffic_controller_site.rb
@@ -41,10 +41,11 @@ module RSMP
         signal_plans.each_pair do |id,settings|
           states = nil
           bands = nil
+          cycle_time = settings['cycle_time']
           states = settings['states'] if settings
           dynamic_bands = settings['dynamic_bands'] if settings
 
-          @signal_plans[id.to_i] = SignalPlan.new(nr: id.to_i, states:states,dynamic_bands:dynamic_bands)
+          @signal_plans[id.to_i] = SignalPlan.new(nr: id.to_i, cycle_time: cycle_time, states: states, dynamic_bands: dynamic_bands)
         end
       end
 
@@ -59,7 +60,6 @@ module RSMP
             id: id,
             ntsOId: settings['ntsOId'],
             xNId: settings['xNId'],
-            cycle_time: settings['cycle_time'],
             startup_sequence: @startup_sequence,
             signal_plans: @signal_plans,
             live_output: @site_settings['live_output'],

--- a/lib/rsmp/version.rb
+++ b/lib/rsmp/version.rb
@@ -1,3 +1,3 @@
 module RSMP
-  VERSION = "0.32.8"
+  VERSION = "0.33.0"
 end


### PR DESCRIPTION
…for each signal plan

Previous the M0018 command was supported but didn't actually do anything.

Now it actually changes the cycle time. This will be reflected if you read the cycle time with M0028.
When running a signal plan with is extended, the last state of each group will be extended up to the  cycle time.

As part of this change, the cycle time is now configured for each signal plan, and was removed from the main component.
